### PR TITLE
Update SiteMethods.py

### DIFF
--- a/OQSrtk/SiteMethods.py
+++ b/OQSrtk/SiteMethods.py
@@ -138,9 +138,9 @@ def QwlImpedance(qwvs, qwdn, vsr=[], dnr=[]):
 
   # Reference default
   if not vsr:
-    vsr = qwvs[-1]
+    vsr = qwvs[0]
   if not dnr:
-    dnr = qwdn[-1]
+    dnr = qwdn[0]
 
   # Computing amplification function
   qwaf = _np.sqrt((dnr*vsr)/(qwdn*qwvs))


### PR DESCRIPTION
The QWL Vs array and Dn array are reversed (Python 3). The base reference velocities/densities are located at the beginning of the array. 
Right now this uses the surface Vs/Density as the reference, so the resultant QWL amplification is much lower than it should be.